### PR TITLE
Fixed Character customization bug

### DIFF
--- a/src/org/worldgrower/gui/start/CharacterCustomizationScreen.java
+++ b/src/org/worldgrower/gui/start/CharacterCustomizationScreen.java
@@ -508,13 +508,13 @@ public class CharacterCustomizationScreen extends JFrame {
 		attributePoints++;
 		attributeLabel.setText(Integer.toString(attributePoints));
 		
-		handleMinMaxValues();
-		
 		if (attributePoints > 0) {
 			for(JButton plusButton : plusButtons) {
 				plusButton.setEnabled(true);
 			}
 		}
+		
+		handleMinMaxValues();
 	}
 	
 	private List<String> validateInput() {


### PR DESCRIPTION
When creating a custom game, player could put over 20 points in one attribute.

This was caused by a bug in CharacterCustomizationScreen class decrementAttributeValue method where all plusButtons were set to enabled after one of the attributes was decremented. (This is easily tested by maxing one attribute and then clicking minus of another)

Solution proposal is to move handleMinMaxValues check after the enabling operation.